### PR TITLE
updates unified function/method declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ For functions and init methods, prefer named parameters for all arguments unless
 
 ```swift
 func dateFromString(dateString: String) -> NSDate
-func convertPointAt(#column: Int, #row: Int) -> CGPoint
-func timedAction(#delay: NSTimeInterval, perform action: SKAction) -> SKAction!
+func convertPointAt(column column: Int, row: Int) -> CGPoint
+func timedAction(delay delay: NSTimeInterval, perform action: SKAction) -> SKAction!
 
 // would be called like this:
 dateFromString("2014-03-14")


### PR DESCRIPTION
The # syntax for required/expressive argument declarations is
deprecated. This commit updates to the newest syntax.
